### PR TITLE
Add strategyType and owner to events

### DIFF
--- a/cadence/contracts/FlowYieldVaults.cdc
+++ b/cadence/contracts/FlowYieldVaults.cdc
@@ -306,9 +306,9 @@ access(all) contract FlowYieldVaults {
         access(all) view fun isSupportedVaultType(type: Type): Bool {
             return self.getSupportedVaultTypes()[type] ?? false
         }
-        /// Returns the Type of the Strategy encapsulated by this YieldVault
-        access(all) view fun getStrategyType(): Type? {
-            return self.strategy?.getType()
+        /// Returns the strategy type identifier for this YieldVault
+        access(all) view fun getStrategyType(): String {
+            return self.strategy.getType().identifier
         }
         /// Withdraws the requested amount from the Strategy
         access(FungibleToken.Withdraw) fun withdraw(amount: UFix64): @{FungibleToken.Vault} {


### PR DESCRIPTION
Closes: #???

## Description

Add `strategyType` to deposit/withdraw events and `owner` to BurnedYieldVault for improved event filtering and activity tracking

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/FlowYieldVaults-sc/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 