### PR TITLE
Validate beta and clean up grants

### DIFF
--- a/cadence/contracts/FlowYieldVaults.cdc
+++ b/cadence/contracts/FlowYieldVaults.cdc
@@ -438,6 +438,10 @@ access(all) contract FlowYieldVaults {
     }
     /// Creates a YieldVaultManager used to create and manage YieldVaults
     access(all) fun createYieldVaultManager(betaRef: auth(FlowYieldVaultsClosedBeta.Beta) &FlowYieldVaultsClosedBeta.BetaBadge): @ YieldVaultManager {
+        pre {
+            FlowYieldVaultsClosedBeta.validateBeta(betaRef.getOwner(), betaRef):
+            "Invalid Beta Ref"
+        }
         return <-create YieldVaultManager()
     }
     /// Creates a StrategyFactory resource


### PR DESCRIPTION
## Summary
- delete old beta capability controllers before reissuing
- validate beta refs in createYieldVaultManager

## Testing
- not run