### PR TITLE
add maximum possible size data for estimateSchedulingCost in Supervisor

### DIFF
--- a/cadence/contracts/FlowYieldVaultsSchedulerV1.cdc
+++ b/cadence/contracts/FlowYieldVaultsSchedulerV1.cdc
@@ -349,8 +349,14 @@ access(all) contract FlowYieldVaultsSchedulerV1 {
         priority: FlowTransactionScheduler.Priority,
         executionEffort: UInt64
     ): FlowTransactionScheduler.EstimatedScheduledTransaction {
+        let maximumSizeData: {String: AnyStruct} = {
+            "priority": priority.rawValue,
+            "executionEffort": executionEffort,
+            "recurringInterval": UFix64.max,
+            "scanForStuck": true
+        }
         return FlowTransactionScheduler.estimate(
-            data: nil,
+            data: maximumSizeData,
             timestamp: timestamp,
             priority: priority,
             executionEffort: executionEffort


### PR DESCRIPTION
Closes: #135 

## Description

Fee estimation in FlowTransactionScheduler depends on the size of the data payload, ignoring the payload during estimation can under-estimate flowFee.
Added the maximum possible data which could be given to FlowTransactionScheduler.schedule without changing the method.