### PR TITLE
perf: optimize pending queue lookup from O(n) to O(1)

### DIFF
--- a/cadence/contracts/FlowYieldVaultsSchedulerRegistry.cdc
+++ b/cadence/contracts/FlowYieldVaultsSchedulerRegistry.cdc
@@ -153,6 +153,11 @@ access(all) contract FlowYieldVaultsSchedulerRegistry {
         return self.pendingQueue.keys
     }
 
+    /// Check if a yield vault ID is in the pending queue - O(1) lookup
+    access(all) view fun isPending(yieldVaultID: UInt64): Bool {
+        return self.pendingQueue.containsKey(yieldVaultID)
+    }
+
     /// Get paginated pending yield vault IDs
     /// @param page: The page number (0-indexed)
     /// @param size: The page size (defaults to MAX_BATCH_SIZE if nil)

--- a/cadence/contracts/FlowYieldVaultsSchedulerV1.cdc
+++ b/cadence/contracts/FlowYieldVaultsSchedulerV1.cdc
@@ -186,9 +186,7 @@ access(all) contract FlowYieldVaultsSchedulerV1 {
                     scanned = scanned + 1
                     
                     // Skip if already in pending queue
-                    // TODO: This is extremely inefficient - accessing from mapping is preferrable to iterating over
-                    //      an array
-                    if FlowYieldVaultsSchedulerRegistry.getPendingYieldVaultIDs().contains(yieldVaultID) {
+                    if FlowYieldVaultsSchedulerRegistry.isPending(yieldVaultID: yieldVaultID) {
                         continue
                     }
 


### PR DESCRIPTION
Add isPending() function to registry for direct dictionary lookup instead of iterating over array returned by getPendingYieldVaultIDs().

Closes: #???

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/FlowYieldVaults-sc/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 