### PR TITLE
Fix emulator setup after FlowCreditMarket simple-curve removal

### DIFF
--- a/flow.json
+++ b/flow.json
@@ -188,6 +188,15 @@
 				"testnet": "426f0458ced60037"
 			}
 		},
+		"MockDexSwapper": {
+			"source": "./lib/FlowCreditMarket/cadence/contracts/mocks/MockDexSwapper.cdc",
+			"aliases": {
+				"emulator": "045a1763c93006ca",
+				"mainnet": "6b00ff876c299c61",
+				"testing": "0000000000000008",
+				"testnet": "426f0458ced60037"
+			}
+		},
 		"MockFlowCreditMarketConsumer": {
 			"source": "./lib/FlowCreditMarket/cadence/contracts/mocks/MockFlowCreditMarketConsumer.cdc",
 			"aliases": {
@@ -809,6 +818,7 @@
 				"FungibleTokenConnectors",
 				"SwapConnectors",
 				"DummyConnectors",
+				"MockDexSwapper",
 				"FlowCreditMarket",
 				{
 					"name": "YieldToken",

--- a/local/setup_emulator.sh
+++ b/local/setup_emulator.sh
@@ -23,7 +23,7 @@ flow transactions send ./cadence/transactions/mocks/oracle/set_price.cdc 'A.045a
 # create Pool with MOET as default token
 flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-factory/create_and_store_pool.cdc 'A.045a1763c93006ca.MOET.Vault' --signer emulator-flow-yield-vaults
 # add FLOW as supported token - params: collateralFactor, borrowFactor, depositRate, depositCapacityCap
-flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/add_supported_token_simple_interest_curve.cdc \
+flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/add_supported_token_zero_rate_curve.cdc \
     'A.0ae53cb6e3f42a79.FlowToken.Vault' \
     0.8 \
     1.0 \
@@ -67,4 +67,3 @@ flow transactions send ./lib/FlowCreditMarket/cadence/tests/transactions/flow-cr
 TIDAL_COA=0x$(flow scripts execute ./lib/flow-evm-bridge/cadence/scripts/evm/get_evm_address_string.cdc 045a1763c93006ca --format inline | sed -E 's/"([^"]+)"/\1/')
 echo $TIDAL_COA
 flow transactions send ./lib/flow-evm-bridge/cadence/transactions/flow-token/transfer_flow_to_cadence_or_evm.cdc $TIDAL_COA 100.0 --signer emulator-flow-yield-vaults --gas-limit 9999
-

--- a/local/setup_mainnet.sh
+++ b/local/setup_mainnet.sh
@@ -22,7 +22,7 @@ flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-m
 flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/update_oracle.cdc --network mainnet --signer mainnet-flow-credit-market-deployer
 
 # add FLOW as supported token - params: collateralFactor, borrowFactor, depositRate, depositCapacityCap
-flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/add_supported_token_simple_interest_curve.cdc \
+flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/add_supported_token_zero_rate_curve.cdc \
     'A.1654653399040a61.FlowToken.Vault' \
     0.8 \
     1.0 \
@@ -38,7 +38,7 @@ cd ./lib/FlowCreditMarket/FlowActions && flow transactions send ./cadence/transa
 cd ./lib/FlowCreditMarket/FlowActions && flow transactions send ./cadence/transactions/band-oracle-connector/add_symbol.cdc "ETH" "A.1e4aa0b87d10b141.EVMVMBridgedToken_2f6f07cdcf3588944bf4c42ac74ff24bf56e7590.Vault" --network mainnet --signer mainnet-band-oracle-connectors && cd ../../..
 
 # WBTC simple curve
-flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/add_supported_token_simple_interest_curve.cdc \
+flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/add_supported_token_zero_rate_curve.cdc \
     'A.1e4aa0b87d10b141.EVMVMBridgedToken_717dae2baf7656be9a9b01dee31d571a9d4c9579.Vault' \
     0.8 \
     1.0 \
@@ -48,7 +48,7 @@ flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-m
     --signer mainnet-flow-credit-market-deployer
 
 # WETH simple curve
-flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/add_supported_token_simple_interest_curve.cdc \
+flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/add_supported_token_zero_rate_curve.cdc \
     'A.1e4aa0b87d10b141.EVMVMBridgedToken_2f6f07cdcf3588944bf4c42ac74ff24bf56e7590.Vault' \
     0.8 \
     1.0 \

--- a/local/setup_testnet.sh
+++ b/local/setup_testnet.sh
@@ -22,7 +22,7 @@ flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-m
 # update Pool with Band Oracle instead of Mock Oracle
 flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/update_oracle.cdc --network testnet --signer testnet-flow-credit-market-deployer
 # add FLOW as supported token - params: collateralFactor, borrowFactor, depositRate, depositCapacityCap
-flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/add_supported_token_simple_interest_curve.cdc \
+flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/add_supported_token_zero_rate_curve.cdc \
     'A.7e60df042a9c0868.FlowToken.Vault' \
     0.8 \
     1.0 \
@@ -38,7 +38,7 @@ cd ./lib/FlowCreditMarket/FlowActions && flow transactions send ./cadence/transa
 cd ./lib/FlowCreditMarket/FlowActions && flow transactions send ./cadence/transactions/band-oracle-connector/add_symbol.cdc "ETH" "A.dfc20aee650fcbdf.EVMVMBridgedToken_059a77239dafa770977dd9f1e98632c3e4559848.Vault" --network testnet --signer testnet-band-oracle-connectors && cd ../../..
 
 # add WBTC as supported token
-flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/add_supported_token_simple_interest_curve.cdc \
+flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/add_supported_token_zero_rate_curve.cdc \
     'A.dfc20aee650fcbdf.EVMVMBridgedToken_208d09d2a6dd176e3e95b3f0de172a7471c5b2d6.Vault' \
     0.8 \
     1.0 \
@@ -48,7 +48,7 @@ flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-m
     --signer testnet-flow-credit-market-deployer
 
 # add WETH as supported token
-flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/add_supported_token_simple_interest_curve.cdc \
+flow transactions send ./lib/FlowCreditMarket/cadence/transactions/flow-credit-market/pool-governance/add_supported_token_zero_rate_curve.cdc \
     'A.dfc20aee650fcbdf.EVMVMBridgedToken_059a77239dafa770977dd9f1e98632c3e4559848.Vault' \
     0.8 \
     1.0 \


### PR DESCRIPTION
Summary:
- add MockDexSwapper to flow.json contracts
- include MockDexSwapper in emulator deployment order before FlowCreditMarket
- update setup scripts to use add_supported_token_zero_rate_curve.cdc (replacement for removed add_supported_token_simple_interest_curve.cdc)

Why:
./local/setup_and_run_emulator.sh was failing during setup with unresolved MockDexSwapper imports and missing simple-curve transaction file.
This aligns setup scripts/config with the current FlowCreditMarket transaction set and import requirements.
