### PR TITLE
Add check for balance increase on yield increase

### DIFF
--- a/cadence/tests/balance_test.cdc
+++ b/cadence/tests/balance_test.cdc
@@ -1,0 +1,151 @@
+
+import Test
+import BlockchainHelpers
+
+import "test_helpers.cdc"
+
+import "FlowToken"
+import "MOET"
+import "YieldToken"
+import "FlowYieldVaultsStrategies"
+
+access(all) let protocolAccount = Test.getAccount(0x0000000000000008)
+access(all) let flowYieldVaultsAccount = Test.getAccount(0x0000000000000009)
+access(all) let yieldTokenAccount = Test.getAccount(0x0000000000000010)
+
+access(all) var strategyIdentifier = Type<@FlowYieldVaultsStrategies.TracerStrategy>().identifier
+access(all) var flowTokenIdentifier = Type<@FlowToken.Vault>().identifier
+access(all) var yieldTokenIdentifier = Type<@YieldToken.Vault>().identifier
+access(all) var moetTokenIdentifier = Type<@MOET.Vault>().identifier
+
+access(all) let collateralFactor = 0.8
+access(all) let targetHealthFactor = 1.3
+
+access(all) var snapshot: UInt64 = 0
+
+access(all)
+fun setup() {
+    deployContracts()
+
+    // set mocked token prices
+    setMockOraclePrice(signer: flowYieldVaultsAccount, forTokenIdentifier: yieldTokenIdentifier, price: 1.0)
+    setMockOraclePrice(signer: flowYieldVaultsAccount, forTokenIdentifier: flowTokenIdentifier, price: 1.0)
+
+    // mint tokens & set liquidity in mock swapper contract
+    let reserveAmount = 100_000_00.0
+    setupYieldVault(protocolAccount, beFailed: false)
+    mintFlow(to: protocolAccount, amount: reserveAmount)
+    mintMoet(signer: protocolAccount, to: protocolAccount.address, amount: reserveAmount, beFailed: false)
+    mintYield(signer: yieldTokenAccount, to: protocolAccount.address, amount: reserveAmount, beFailed: false)
+    setMockSwapperLiquidityConnector(signer: protocolAccount, vaultStoragePath: MOET.VaultStoragePath)
+    setMockSwapperLiquidityConnector(signer: protocolAccount, vaultStoragePath: YieldToken.VaultStoragePath)
+    setMockSwapperLiquidityConnector(signer: protocolAccount, vaultStoragePath: /storage/flowTokenVault)
+
+    // setup FlowALP with a Pool & add FLOW as supported token
+    createAndStorePool(signer: protocolAccount, defaultTokenIdentifier: moetTokenIdentifier, beFailed: false)
+    addSupportedTokenFixedRateInterestCurve(
+        signer: protocolAccount,
+        tokenTypeIdentifier: flowTokenIdentifier,
+        collateralFactor: 0.8,
+        borrowFactor: 1.0,
+        yearlyRate: UFix128(0.0),
+        depositRate: 1_000_000.0,
+        depositCapacityCap: 1_000_000.0
+    )
+
+    // open wrapped position (pushToDrawDownSink)
+    // the equivalent of depositing reserves
+    let openRes = executeTransaction(
+        "../../lib/FlowALP/cadence/transactions/flow-alp/position/create_position.cdc",
+        [reserveAmount/2.0, /storage/flowTokenVault, true],
+        protocolAccount
+    )
+    Test.expect(openRes, Test.beSucceeded())
+
+    // enable mocked Strategy creation
+    addStrategyComposer(
+        signer: flowYieldVaultsAccount,
+        strategyIdentifier: strategyIdentifier,
+        composerIdentifier: Type<@FlowYieldVaultsStrategies.TracerStrategyComposer>().identifier,
+        issuerStoragePath: FlowYieldVaultsStrategies.IssuerStoragePath,
+        beFailed: false
+    )
+
+    // Fund FlowYieldVaults account for scheduling fees (atomic initial scheduling)
+    mintFlow(to: flowYieldVaultsAccount, amount: 100.0)
+
+    snapshot = getCurrentBlockHeight()
+}
+
+access(all)
+fun test_RebalanceYieldVaultScenario2() {
+    // Test.reset(to: snapshot)
+
+    let fundingAmount = 1625.0
+
+    let user = Test.createAccount()
+
+    let yieldTokenPrice = 1.01
+    let expectedFlowBalance = 1634.09090909
+    
+
+    // Likely 0.0
+    let flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
+    mintFlow(to: user, amount: fundingAmount)
+    grantBeta(flowYieldVaultsAccount, user)
+
+    createYieldVault(
+        signer: user,
+        strategyIdentifier: strategyIdentifier,
+        vaultIdentifier: flowTokenIdentifier,
+        amount: fundingAmount,
+        beFailed: false
+    )
+
+    var yieldVaultIDs = getYieldVaultIDs(address: user.address)
+    var pid  = 1 as UInt64
+    log("[TEST] YieldVault ID: \(yieldVaultIDs![0])")
+    Test.assert(yieldVaultIDs != nil, message: "Expected user's YieldVault IDs to be non-nil but encountered nil")
+    Test.assertEqual(1, yieldVaultIDs!.length)
+
+    var yieldVaultBalance = getYieldVaultBalance(address: user.address, yieldVaultID: yieldVaultIDs![0])
+
+    log("[TEST] Initial yield vault balance: \(yieldVaultBalance ?? 0.0)")
+
+    rebalanceYieldVault(signer: flowYieldVaultsAccount, id: yieldVaultIDs![0], force: true, beFailed: false)
+    rebalancePosition(signer: protocolAccount, pid: pid, force: true, beFailed: false)
+
+    yieldVaultBalance = getYieldVaultBalance(address: user.address, yieldVaultID: yieldVaultIDs![0])
+
+    log("[TEST] YieldVault balance before yield price \(yieldTokenPrice): \(yieldVaultBalance ?? 0.0)")
+
+    setMockOraclePrice(signer: flowYieldVaultsAccount, forTokenIdentifier: yieldTokenIdentifier, price: yieldTokenPrice)
+
+    yieldVaultBalance = getYieldVaultBalance(address: user.address, yieldVaultID: yieldVaultIDs![0])
+
+    log("[TEST] YieldVault balance before yield price \(yieldTokenPrice) rebalance: \(yieldVaultBalance ?? 0.0)")
+
+    rebalanceYieldVault(signer: flowYieldVaultsAccount, id: yieldVaultIDs![0], force: false, beFailed: false)
+    rebalancePosition(signer: protocolAccount, pid: pid, force: false, beFailed: false)
+
+    yieldVaultBalance = getYieldVaultBalance(address: user.address, yieldVaultID: yieldVaultIDs![0])
+
+    log("[TEST] YieldVault balance after yield before \(yieldTokenPrice) rebalance: \(yieldVaultBalance ?? 0.0)")
+
+    Test.assert(
+        yieldVaultBalance == expectedFlowBalance,
+        message: "YieldVault balance of \(yieldVaultBalance ?? 0.0) doesn't match an expected value \(expectedFlowBalance)"
+    )
+    
+
+    closeYieldVault(signer: user, id: yieldVaultIDs![0], beFailed: false)
+
+    let flowBalanceAfter = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
+    log("[TEST] flow balance after \(flowBalanceAfter)")
+
+    Test.assert(
+        equalAmounts(a: flowBalanceAfter, b: expectedFlowBalance, tolerance: 0.01),
+        message: "Expected user's Flow balance after rebalance to be more than zero but got \(flowBalanceAfter)"
+    )
+}
+


### PR DESCRIPTION
Closes: 

## Description

Add check for balance increase on yield increase

```
12:51PM INF LOG: "Deploying Morpho contracts..."
12:51PM INF LOG: "deploy PunchswapV3Factory"
12:51PM INF LOG: "PunchswapV3Factory address 8b8725c1281610b6b59203c91c5961dbce4eba73"
12:51PM INF LOG: "deploy NFTDescriptor"
12:51PM INF LOG: "NFTDescriptor address cfaf1b59f7a0b8714084c551ff0d705d29453028"
12:51PM INF LOG: "deploy NFTPositionDescriptor"
12:51PM INF LOG: "NFTPositionDescriptor address a4ff9e51fe723a2cfd9ef6ec4f1dba20e03d4633"
12:51PM INF LOG: "deploy UniswapV2Factory"
12:51PM INF LOG: "UniswapV2Factory address b8ef4a292ead7459b54b3adfab491d86ba39511c"
12:51PM INF LOG: "deploy NonfungiblePositionManager"
12:51PM INF LOG: "NonfungiblePositionManager address bc3ff1b178c3f6e439264bcfe042e8afaa799090"
12:51PM INF LOG: "deploy SwapRouter02"
12:51PM INF LOG: "SwapRouter address 511beb3c362ab7aecd22ec354c5a06d6e83fa576"
12:51PM INF LOG: "deploy QuoterV2"
12:51PM INF LOG: "QuoterV2 address 44c925fbabd5c722526a81a7b584832e6759ab45"
12:51PM INF LOG: "[TEST] YieldVault ID: 0"
12:51PM INF LOG: "[TEST] Initial yield vault balance: 1625.00000000"
12:51PM INF LOG: "[TEST] YieldVault balance before yield price 1.01000000: 1625.00000000"
12:51PM INF LOG: "[TEST] YieldVault balance before yield price 1.01000000 rebalance: 1634.09090909"
12:51PM INF LOG: "[TEST] YieldVault balance after yield before 1.01000000 rebalance: 1634.09090909"
12:51PM INF LOG: "[TEST] flow balance after 1634.09090909"

Test results: "cadence/tests/balance_test.cdc"
- PASS: test_RebalanceYieldVaultScenario2
```

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/FlowYieldVaults-sc/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 