### PR TITLE
chore: update Flow dependency metadata

### DIFF
--- a/flow.json
+++ b/flow.json
@@ -178,16 +178,6 @@
 				"testnet": "d2580caf2ef07c2f"
 			}
 		},
-		"MockStrategies": {
-			"source": "cadence/contracts/mocks/MockStrategies.cdc",
-			"aliases": {
-				"emulator": "045a1763c93006ca",
-				"mainnet": "b1d63873c3cc9f79",
-				"mainnet-fork": "b1d63873c3cc9f79",
-				"testing": "0000000000000009",
-				"testnet": "d2580caf2ef07c2f"
-			}
-		},
 		"FlowYieldVaultsStrategiesV2": {
 			"source": "cadence/contracts/FlowYieldVaultsStrategiesV2.cdc",
 			"aliases": {
@@ -227,6 +217,16 @@
 		},
 		"MockOracle": {
 			"source": "cadence/contracts/mocks/MockOracle.cdc",
+			"aliases": {
+				"emulator": "045a1763c93006ca",
+				"mainnet": "b1d63873c3cc9f79",
+				"mainnet-fork": "b1d63873c3cc9f79",
+				"testing": "0000000000000009",
+				"testnet": "d2580caf2ef07c2f"
+			}
+		},
+		"MockStrategies": {
+			"source": "cadence/contracts/mocks/MockStrategies.cdc",
 			"aliases": {
 				"emulator": "045a1763c93006ca",
 				"mainnet": "b1d63873c3cc9f79",
@@ -318,7 +318,7 @@
 		"ArrayUtils": {
 			"source": "mainnet://1e4aa0b87d10b141.ArrayUtils",
 			"hash": "e70ddc2f0c7c72158a3f6c68de3a131e1f49e2908ad83eac0308f9e2953957d5",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -329,7 +329,7 @@
 		"BandOracle": {
 			"source": "mainnet://6801a6222ebf784a.BandOracle",
 			"hash": "ababa195ef50b63d71520022aa2468656a9703b924c0f5228cfaa51a71db094d",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "045a1763c93006ca",
 				"mainnet": "6801a6222ebf784a",
@@ -341,7 +341,7 @@
 		"Burner": {
 			"source": "mainnet://f233dcee88fe0abe.Burner",
 			"hash": "71af18e227984cd434a3ad00bb2f3618b76482842bae920ee55662c37c8bf331",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "f233dcee88fe0abe",
@@ -352,7 +352,7 @@
 		"CrossVMMetadataViews": {
 			"source": "mainnet://1d7e57aa55817448.CrossVMMetadataViews",
 			"hash": "7e79b77b87c750de5b126ebd6fca517c2b905ac7f01c0428e9f3f82838c7f524",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1d7e57aa55817448",
@@ -363,7 +363,7 @@
 		"CrossVMNFT": {
 			"source": "mainnet://1e4aa0b87d10b141.CrossVMNFT",
 			"hash": "8fe69f487164caffedab68b52a584fa7aa4d54a0061f4f211998c73a619fbea5",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -374,7 +374,7 @@
 		"CrossVMToken": {
 			"source": "mainnet://1e4aa0b87d10b141.CrossVMToken",
 			"hash": "9f055ad902e7de5619a2b0f2dc91826ac9c4f007afcd6df9f5b8229c0ca94531",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -386,7 +386,7 @@
 		"EVM": {
 			"source": "mainnet://e467b9dd11fa00df.EVM",
 			"hash": "960b0c7df7ee536956af196fba8c8d5dd4f7a89a4ecc61467e31287c4617b0dd",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "e467b9dd11fa00df",
@@ -397,7 +397,7 @@
 		"FlowEVMBridge": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridge",
 			"hash": "9cd0f897b19c0394e9042225e5758d6ae529a0cce19b19ae05bde8e0f14aa10b",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -409,7 +409,7 @@
 		"FlowEVMBridgeAccessor": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeAccessor",
 			"hash": "888ba0aab5e961924c47b819f4a9f410449c39745e0d3eab20738bf10ef2ed0f",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -421,7 +421,7 @@
 		"FlowEVMBridgeConfig": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeConfig",
 			"hash": "3c09f74467f22dac7bc02b2fdf462213b2f8ddfb513cd890ad0c2a7016507be3",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -433,7 +433,7 @@
 		"FlowEVMBridgeCustomAssociationTypes": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeCustomAssociationTypes",
 			"hash": "4651183c3f04f8c5faaa35106b3ab66060ce9868590adb33f3be1900c12ea196",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -445,7 +445,7 @@
 		"FlowEVMBridgeCustomAssociations": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeCustomAssociations",
 			"hash": "14d1f4ddd347f45d331e543830b94701e1aa1513c56d55c0019c7fac46d8a572",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -457,7 +457,7 @@
 		"FlowEVMBridgeHandlerInterfaces": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeHandlerInterfaces",
 			"hash": "e32154f2a556e53328a0fce75f1e98b57eefd2a8cb626e803b7d39d452691444",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -469,7 +469,7 @@
 		"FlowEVMBridgeHandlers": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeHandlers",
 			"hash": "7e8adff1dca0ea1d2e361c17de9eca020f82cabc00a52679078752bf85adb004",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -481,7 +481,7 @@
 		"FlowEVMBridgeNFTEscrow": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeNFTEscrow",
 			"hash": "30257592838edfd4b72700f43bf0326f6903e879f82ac5ca549561d9863c6fe6",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -493,7 +493,7 @@
 		"FlowEVMBridgeResolver": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeResolver",
 			"hash": "c1ac18e92828616771df5ff5d6de87866f2742ca4ce196601c11e977e4f63bb3",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -505,7 +505,7 @@
 		"FlowEVMBridgeTemplates": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeTemplates",
 			"hash": "78b8115eb0ef2be4583acbe655f0c5128c39712084ec23ce47820ea154141898",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -517,7 +517,7 @@
 		"FlowEVMBridgeTokenEscrow": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeTokenEscrow",
 			"hash": "49df9c8e5d0dd45abd5bf94376d3b9045299b3c2a5ba6caf48092c916362358d",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -529,7 +529,7 @@
 		"FlowEVMBridgeUtils": {
 			"source": "mainnet://1e4aa0b87d10b141.FlowEVMBridgeUtils",
 			"hash": "634ed6dde03eb8f027368aa7861889ce1f5099160903493a7a39a86c9afea14b",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -541,7 +541,7 @@
 		"FlowFees": {
 			"source": "mainnet://f919ee77447b7497.FlowFees",
 			"hash": "341cc0f3cc847d6b787c390133f6a5e6c867c111784f09c5c0083c47f2f1df64",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "e5a8b7f23e8b548f",
 				"mainnet": "f919ee77447b7497",
@@ -552,7 +552,7 @@
 		"FlowStorageFees": {
 			"source": "mainnet://e467b9dd11fa00df.FlowStorageFees",
 			"hash": "a92c26fb2ea59725441fa703aa4cd811e0fc56ac73d649a8e12c1e72b67a8473",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "e467b9dd11fa00df",
@@ -563,7 +563,7 @@
 		"FlowToken": {
 			"source": "mainnet://1654653399040a61.FlowToken",
 			"hash": "f82389e2412624ffa439836b00b42e6605b0c00802a4e485bc95b8930a7eac38",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "0ae53cb6e3f42a79",
 				"mainnet": "1654653399040a61",
@@ -574,7 +574,7 @@
 		"FlowTransactionScheduler": {
 			"source": "mainnet://e467b9dd11fa00df.FlowTransactionScheduler",
 			"hash": "23157cf7d70534e45b0ab729133232d0ffb3cdae52661df1744747cb1f8c0495",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "e467b9dd11fa00df",
@@ -585,7 +585,7 @@
 		"FlowTransactionSchedulerUtils": {
 			"source": "mainnet://e467b9dd11fa00df.FlowTransactionSchedulerUtils",
 			"hash": "71a1febab6b9ba76abec36dab1e61b1c377e44fbe627e5fac649deb71b727877",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "e467b9dd11fa00df",
@@ -596,7 +596,7 @@
 		"FungibleToken": {
 			"source": "mainnet://f233dcee88fe0abe.FungibleToken",
 			"hash": "4b74edfe7d7ddfa70b703c14aa731a0b2e7ce016ce54d998bfd861ada4d240f6",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "ee82856bf20e2aa6",
 				"mainnet": "f233dcee88fe0abe",
@@ -607,7 +607,7 @@
 		"FungibleTokenMetadataViews": {
 			"source": "mainnet://f233dcee88fe0abe.FungibleTokenMetadataViews",
 			"hash": "70477f80fd7678466c224507e9689f68f72a9e697128d5ea54d19961ec856b3c",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "ee82856bf20e2aa6",
 				"mainnet": "f233dcee88fe0abe",
@@ -618,7 +618,7 @@
 		"IBridgePermissions": {
 			"source": "mainnet://1e4aa0b87d10b141.IBridgePermissions",
 			"hash": "431a51a6cca87773596f79832520b19499fe614297eaef347e49383f2ae809af",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -629,7 +629,7 @@
 		"ICrossVM": {
 			"source": "mainnet://1e4aa0b87d10b141.ICrossVM",
 			"hash": "b95c36eef516da7cd4d2f507cd48288cc16b1d6605ff03b6fcd18161ff2d82e7",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -641,7 +641,7 @@
 		"ICrossVMAsset": {
 			"source": "mainnet://1e4aa0b87d10b141.ICrossVMAsset",
 			"hash": "d9c7b2bd9fdcc454180c33b3509a5a060a7fe4bd49bce38818f22fd08acb8ba0",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -653,7 +653,7 @@
 		"IEVMBridgeNFTMinter": {
 			"source": "mainnet://1e4aa0b87d10b141.IEVMBridgeNFTMinter",
 			"hash": "e2ad15c495ad7fbf4ab744bccaf8c4334dfb843b50f09e9681ce9a5067dbf049",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -665,7 +665,7 @@
 		"IEVMBridgeTokenMinter": {
 			"source": "mainnet://1e4aa0b87d10b141.IEVMBridgeTokenMinter",
 			"hash": "0ef39c6cb476f0eea2c835900b6a5a83c1ed5f4dbaaeb29cb68ad52c355a40e6",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -677,7 +677,7 @@
 		"IFlowEVMNFTBridge": {
 			"source": "mainnet://1e4aa0b87d10b141.IFlowEVMNFTBridge",
 			"hash": "2d495e896510a10bbc7307739aca9341633cac4c7fe7dad32488a81f90a39dd9",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -689,7 +689,7 @@
 		"IFlowEVMTokenBridge": {
 			"source": "mainnet://1e4aa0b87d10b141.IFlowEVMTokenBridge",
 			"hash": "87f7d752da8446e73acd3bf4aa17fe5c279d9641b7976c56561af01bc5240ea4",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -701,7 +701,7 @@
 		"MetadataViews": {
 			"source": "mainnet://1d7e57aa55817448.MetadataViews",
 			"hash": "b290b7906d901882b4b62e596225fb2f10defb5eaaab4a09368f3aee0e9c18b1",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1d7e57aa55817448",
@@ -712,7 +712,7 @@
 		"NonFungibleToken": {
 			"source": "mainnet://1d7e57aa55817448.NonFungibleToken",
 			"hash": "a258de1abddcdb50afc929e74aca87161d0083588f6abf2b369672e64cf4a403",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1d7e57aa55817448",
@@ -723,7 +723,7 @@
 		"ScopedFTProviders": {
 			"source": "mainnet://1e4aa0b87d10b141.ScopedFTProviders",
 			"hash": "77213f9588ec9862d07c4706689424ad7c1d8f043d5970d96bf18764bb936fc3",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -735,7 +735,7 @@
 		"Serialize": {
 			"source": "mainnet://1e4aa0b87d10b141.Serialize",
 			"hash": "064bb0d7b6c24ee1ed370cbbe9e0cda2a4e0955247de5e3e81f2f3a8a8cabfb7",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -746,7 +746,7 @@
 		"SerializeMetadata": {
 			"source": "mainnet://1e4aa0b87d10b141.SerializeMetadata",
 			"hash": "e9f84ea07e29cae05ee0d9264596eb281c291fc1090a10ce3de1a042b4d671da",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -757,7 +757,7 @@
 		"StableSwapFactory": {
 			"source": "mainnet://b063c16cac85dbd1.StableSwapFactory",
 			"hash": "a63b57a5cc91085016abc34c1b49622b385a8f976ac2ba0e646f7a3f780d344e",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f3fcd2c1a78f5eee",
 				"mainnet": "b063c16cac85dbd1",
@@ -768,7 +768,7 @@
 		"StringUtils": {
 			"source": "mainnet://1e4aa0b87d10b141.StringUtils",
 			"hash": "28ac1a744ac7fb97253cba007a520a9ec1c2e14458d1bd1add1424fa19282c03",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1e4aa0b87d10b141",
@@ -779,7 +779,7 @@
 		"SwapConfig": {
 			"source": "mainnet://b78ef7afa52ff906.SwapConfig",
 			"hash": "111f3caa0ab506bed100225a1481f77687f6ac8493d97e49f149fa26a174ef99",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f3fcd2c1a78f5eee",
 				"mainnet": "b78ef7afa52ff906",
@@ -790,7 +790,7 @@
 		"SwapError": {
 			"source": "mainnet://b78ef7afa52ff906.SwapError",
 			"hash": "7d13a652a1308af387513e35c08b4f9a7389a927bddf08431687a846e4c67f21",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f3fcd2c1a78f5eee",
 				"mainnet": "b78ef7afa52ff906",
@@ -801,7 +801,7 @@
 		"SwapFactory": {
 			"source": "mainnet://b063c16cac85dbd1.SwapFactory",
 			"hash": "deea03edbb49877c8c72276e1911cf87bdba4052ae9c3ac54c0d4ac62f3ef511",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f3fcd2c1a78f5eee",
 				"mainnet": "b063c16cac85dbd1",
@@ -812,7 +812,7 @@
 		"SwapInterfaces": {
 			"source": "mainnet://b78ef7afa52ff906.SwapInterfaces",
 			"hash": "e559dff4d914fa12fff7ba482f30d3c575dc3d31587833fd628763d1a4ee96b2",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f3fcd2c1a78f5eee",
 				"mainnet": "b78ef7afa52ff906",
@@ -823,7 +823,7 @@
 		"SwapRouter": {
 			"source": "mainnet://a6850776a94e6551.SwapRouter",
 			"hash": "c0365c01978ca32af94602bfddd0796cfe6375e60a05b927b5de539e608baec5",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f3fcd2c1a78f5eee",
 				"mainnet": "a6850776a94e6551",
@@ -834,7 +834,7 @@
 		"USDCFlow": {
 			"source": "mainnet://f1ab99c82dee3526.USDCFlow",
 			"hash": "da7c21064dc73c06499f0b652caea447233465b49787605ce0f679beca48dee7",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "f1ab99c82dee3526",
@@ -845,7 +845,7 @@
 		"ViewResolver": {
 			"source": "mainnet://1d7e57aa55817448.ViewResolver",
 			"hash": "374a1994046bac9f6228b4843cb32393ef40554df9bd9907a702d098a2987bde",
-			"block_height": 141772866,
+			"block_height": 143307913,
 			"aliases": {
 				"emulator": "f8d6e0586b0a20c7",
 				"mainnet": "1d7e57aa55817448",


### PR DESCRIPTION
## Summary
- run dependency refresh updates generated by `flow deps install --update`
- update contract dependency metadata block heights in `flow.json`
- preserve existing contract hashes and aliases while refreshing references

## Testing
- not run (metadata-only dependency refresh)