### PR TITLE
Optimize iteration over dictionary keys

### DIFF
--- a/cadence/contracts/FlowYieldVaultsStrategiesV2.cdc
+++ b/cadence/contracts/FlowYieldVaultsStrategiesV2.cdc
@@ -322,7 +322,7 @@ access(all) contract FlowYieldVaultsStrategiesV2 {
         /// Returns the Types of Strategies composed by this StrategyComposer
         access(all) view fun getComposedStrategyTypes(): {Type: Bool} {
             let composed: {Type: Bool} = {}
-            for t in self.config.keys {
+            for t in self.config {
                 composed[t] = true
             }
             return composed
@@ -332,7 +332,7 @@ access(all) contract FlowYieldVaultsStrategiesV2 {
         access(all) view fun getSupportedInitializationVaults(forStrategy: Type): {Type: Bool} {
             let supported: {Type: Bool} = {}
             if let strategyConfig = &self.config[forStrategy] as &{Type: FlowYieldVaultsStrategiesV2.CollateralConfig}? {
-                for collateralType in strategyConfig.keys {
+                for collateralType in strategyConfig {
                     supported[collateralType] = true
                 }
             }
@@ -891,7 +891,7 @@ access(all) contract FlowYieldVaultsStrategiesV2 {
             }
 
             // Validate keys
-            for stratType in config.keys {
+            for stratType in config {
                 assert(stratType.isSubtype(of: Type<@{FlowYieldVaults.Strategy}>()),
                     message: "Invalid config key \(stratType.identifier) - not a FlowYieldVaults.Strategy Type")
                 for collateralType in config[stratType]!.keys {
@@ -904,12 +904,12 @@ access(all) contract FlowYieldVaultsStrategiesV2 {
             let existingComposerConfig = self.configs[composer] ?? {}
             var mergedComposerConfig = existingComposerConfig
 
-            for stratType in config.keys {
+            for stratType in config {
                 let newPerCollateral = config[stratType]!
                 let existingPerCollateral = mergedComposerConfig[stratType] ?? {}
                 var mergedPerCollateral: {Type: FlowYieldVaultsStrategiesV2.CollateralConfig} = existingPerCollateral
 
-                for collateralType in newPerCollateral.keys {
+                for collateralType in newPerCollateral {
                     mergedPerCollateral[collateralType] = newPerCollateral[collateralType]!
                 }
                 mergedComposerConfig[stratType] = mergedPerCollateral

--- a/cadence/contracts/PMStrategiesV1.cdc
+++ b/cadence/contracts/PMStrategiesV1.cdc
@@ -349,7 +349,7 @@ access(all) contract PMStrategiesV1 {
 
         access(all) view fun getComposedStrategyTypes(): {Type: Bool} {
             let composed: {Type: Bool} = {}
-            for t in self.config.keys {
+            for t in self.config {
                 composed[t] = true
             }
             return composed
@@ -593,7 +593,7 @@ access(all) contract PMStrategiesV1 {
                 "Unsupported StrategyComposer Type \(composer.identifier)"
             }
             // Validate keys
-            for stratType in config.keys {
+            for stratType in config {
                 assert(stratType.isSubtype(of: Type<@{FlowYieldVaults.Strategy}>()),
                     message: "Invalid config key \(stratType.identifier) - not a FlowYieldVaults.Strategy Type")
                 for collateralType in config[stratType]!.keys {
@@ -605,12 +605,12 @@ access(all) contract PMStrategiesV1 {
             let existingComposerConfig = self.configs[composer] ?? {}
             var mergedComposerConfig: {Type: {Type: {String: AnyStruct}}} = existingComposerConfig
 
-            for stratType in config.keys {
+            for stratType in config {
                 let newPerCollateral = config[stratType]!
                 let existingPerCollateral = mergedComposerConfig[stratType] ?? {}
                 var mergedPerCollateral: {Type: {String: AnyStruct}} = existingPerCollateral
 
-                for collateralType in newPerCollateral.keys {
+                for collateralType in newPerCollateral {
                     mergedPerCollateral[collateralType] = newPerCollateral[collateralType]!
                 }
                 mergedComposerConfig[stratType] = mergedPerCollateral

--- a/cadence/contracts/mocks/FlowTransactionScheduler.cdc
+++ b/cadence/contracts/mocks/FlowTransactionScheduler.cdc
@@ -652,11 +652,11 @@ access(all) contract FlowTransactionScheduler {
                 
                 var timestampTransactions: {UInt8: [UInt64]} = {}
                 
-                for priority in transactionPriorities.keys {
+                for priority in transactionPriorities {
                     let transactionIDs = transactionPriorities[priority] ?? {}
                     var priorityTransactions: [UInt64] = []
                         
-                    for id in transactionIDs.keys {
+                    for id in transactionIDs {
                         priorityTransactions.append(id)
                     }
                         
@@ -1074,9 +1074,9 @@ access(all) contract FlowTransactionScheduler {
                 var medium: [&TransactionData] = []
                 var low: [&TransactionData] = []
 
-                for priority in transactionPriorities.keys {
+                for priority in transactionPriorities {
                     let transactionIDs = transactionPriorities[priority] ?? {}
-                    for id in transactionIDs.keys {
+                    for id in transactionIDs {
                         let tx = self.borrowTransaction(id: id)
                         if tx == nil {
                             emit CriticalIssue(message: "Invalid ID: \(id) transaction not found while preparing pending queue")
@@ -1129,9 +1129,9 @@ access(all) contract FlowTransactionScheduler {
             for timestamp in pastTimestamps {
                 let transactionPriorities = self.slotQueue[timestamp] ?? {}
                 
-                for priority in transactionPriorities.keys {
+                for priority in transactionPriorities {
                     let transactionIDs = transactionPriorities[priority] ?? {}
-                    for id in transactionIDs.keys {
+                    for id in transactionIDs {
 
                         numRemoved = numRemoved + 1
 

--- a/cadence/contracts/mocks/MockStrategies.cdc
+++ b/cadence/contracts/mocks/MockStrategies.cdc
@@ -139,7 +139,7 @@ access(all) contract MockStrategies {
             var debtCaps: [Capability<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>] = []
             var debtPaths: [StoragePath] = []
 
-            for debtType in debtsByType.keys {
+            for debtType in debtsByType {
                 let debtAmount = debtsByType[debtType]!
                 let swapper = MockSwapper.Swapper(inVault: ytType, outVault: debtType, uniqueID: self.copyID()!)
                 let ytAvailable = ytSource.minimumAvailable()
@@ -420,7 +420,7 @@ access(all) contract MockStrategies {
                 self.getSupportedComposers()[composer] == true:
                 "Unsupported StrategyComposer Type \(composer.identifier)"
             }
-            for stratType in config.keys {
+            for stratType in config {
                 assert(stratType.isSubtype(of: Type<@{FlowYieldVaults.Strategy}>()),
                     message: "Invalid config key \(stratType.identifier) - not a FlowYieldVaults.Strategy Type")
                 for collateralType in config[stratType]!.keys {

--- a/cadence/scripts/flow-yield-vaults/get_complete_user_position_info.cdc
+++ b/cadence/scripts/flow-yield-vaults/get_complete_user_position_info.cdc
@@ -207,7 +207,7 @@ fun main(address: Address): CompleteUserSummary {
             var collateralType = "Unknown"
             let supportedTypes: [String] = []
 
-            for vaultType in supportedVaultTypes.keys {
+            for vaultType in supportedVaultTypes {
                 if supportedVaultTypes[vaultType]! {
                     supportedTypes.append(vaultType.identifier)
                     if collateralType == "Unknown" {

--- a/cadence/tests/test_helpers.cdc
+++ b/cadence/tests/test_helpers.cdc
@@ -824,7 +824,7 @@ fun setBandOraclePrices(signer: Test.TestAccount, symbolPrices: {String: UFix64}
     Test.moveTime(by: 1.0)
     
     let symbolsRates: {String: UInt64} = {}
-    for symbol in symbolPrices.keys {
+    for symbol in symbolPrices {
         // BandOracle uses 1e9 multiplier for prices
         // e.g., $1.00 = 1_000_000_000, $0.50 = 500_000_000
         // Split into whole + fractional to avoid UFix64 overflow for large prices (e.g. BTC > $184)


### PR DESCRIPTION


## Description

Since [Cadence v1.10.0](https://github.com/onflow/cadence/releases/tag/v1.10.0) direct iteration over dictionaries is supported, which avoids temporarily constructing an array of all keys.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-ft/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer