### PR TITLE
Clean up unused variables and parameters

### DIFF
--- a/cadence/contracts/FlowYieldVaultsSchedulerRegistry.cdc
+++ b/cadence/contracts/FlowYieldVaultsSchedulerRegistry.cdc
@@ -147,7 +147,7 @@ access(all) contract FlowYieldVaultsSchedulerRegistry {
     access(account)
     fun setSupervisorCap(cap: Capability<auth(FlowTransactionScheduler.Execute) &{FlowTransactionScheduler.TransactionHandler}>) {
         let storedCapPath = /storage/FlowYieldVaultsSupervisorCapability
-        let old = self.account.storage
+        let _old = self.account.storage
             .load<Capability<auth(FlowTransactionScheduler.Execute) &{FlowTransactionScheduler.TransactionHandler}>>(
                 from: storedCapPath
             )

--- a/cadence/contracts/FlowYieldVaultsSchedulerV1.cdc
+++ b/cadence/contracts/FlowYieldVaultsSchedulerV1.cdc
@@ -175,7 +175,7 @@ access(all) contract FlowYieldVaultsSchedulerV1 {
         ///   "recurringInterval": UFix64 (for Supervisor self-rescheduling)
         ///   "scanForStuck": Bool (default true - scan up to MAX_BATCH_SIZE least-recently-executed recurring scan participants for stuck ones)
         /// }
-        access(FlowTransactionScheduler.Execute) fun executeTransaction(id: UInt64, data: AnyStruct?) {
+        access(FlowTransactionScheduler.Execute) fun executeTransaction(id _: UInt64, data: AnyStruct?) {
             let cfg = data as? {String: AnyStruct} ?? {}
             let priorityRaw = cfg["priority"] as? UInt8 ?? FlowYieldVaultsSchedulerV1.DEFAULT_PRIORITY
             let executionEffort = cfg["executionEffort"] as? UInt64 ?? FlowYieldVaultsSchedulerV1.DEFAULT_EXECUTION_EFFORT

--- a/cadence/contracts/PMStrategiesV1.cdc
+++ b/cadence/contracts/PMStrategiesV1.cdc
@@ -828,11 +828,11 @@ access(all) contract PMStrategiesV1 {
         }
 
         access(all) view fun getViews(): [Type] { return [] }
-        access(all) fun resolveView(_ view: Type): AnyStruct? { return nil }
+        access(all) fun resolveView(_ _view: Type): AnyStruct? { return nil }
 
         /// Called by FlowTransactionScheduler when the timelock expires.
         /// No-ops gracefully if the pending redeem was already cleared.
-        access(FlowTransactionScheduler.Execute) fun executeTransaction(id: UInt64, data: AnyStruct?) {
+        access(FlowTransactionScheduler.Execute) fun executeTransaction(id _: UInt64, data: AnyStruct?) {
             let dataDict = data as? {String: AnyStruct}
                 ?? panic("PendingRedeemHandler: invalid data format")
             let yieldVaultID = dataDict["yieldVaultID"] as? UInt64

--- a/cadence/contracts/mocks/EVM.cdc
+++ b/cadence/contracts/mocks/EVM.cdc
@@ -803,7 +803,6 @@ contract EVM {
         }
 
         // verify evm address matching
-        var addr = coaRef!.address()
         for index, item in coaRef!.address().bytes {
             if item != evmAddress[index] {
                 return ValidationResult(

--- a/cadence/contracts/mocks/FlowTransactionScheduler.cdc
+++ b/cadence/contracts/mocks/FlowTransactionScheduler.cdc
@@ -138,7 +138,7 @@ access(all) contract FlowTransactionScheduler {
             return []
         }
 
-        access(all) fun resolveView(_ view: Type): AnyStruct? {
+        access(all) fun resolveView(_ _view: Type): AnyStruct? {
             return nil
         }
 

--- a/cadence/contracts/mocks/FlowYieldVaultsClosedBeta_validate_beta_false.cdc
+++ b/cadence/contracts/mocks/FlowYieldVaultsClosedBeta_validate_beta_false.cdc
@@ -117,7 +117,7 @@ access(all) contract FlowYieldVaultsClosedBeta {
 
     // TEST-ONLY: Always invalid, regardless of address or reference.
     // Used to ensure beta-gated entrypoints actually call `validateBeta`.
-    access(all) view fun validateBeta(_ addr: Address?, _ betaRef: auth(Beta) &BetaBadge): Bool {
+    access(all) view fun validateBeta(_ _addr: Address?, _ _betaRef: auth(Beta) &BetaBadge): Bool {
         return false
     }
 

--- a/cadence/contracts/mocks/MockStrategies.cdc
+++ b/cadence/contracts/mocks/MockStrategies.cdc
@@ -261,19 +261,19 @@ access(all) contract MockStrategies {
         }
 
         /// Returns the Vault types which can be used to initialize a given Strategy
-        access(all) view fun getSupportedInitializationVaults(forStrategy: Type): {Type: Bool} {
+        access(all) view fun getSupportedInitializationVaults(forStrategy _: Type): {Type: Bool} {
             return { Type<@FlowToken.Vault>(): true }
         }
 
         /// Returns the Vault types which can be deposited to a given Strategy instance if it was initialized with the
         /// provided Vault type
-        access(all) view fun getSupportedInstanceVaults(forStrategy: Type, initializedWith: Type): {Type: Bool} {
+        access(all) view fun getSupportedInstanceVaults(forStrategy _strategy: Type, initializedWith _type: Type): {Type: Bool} {
             return { Type<@FlowToken.Vault>(): true }
         }
 
         /// Composes a Strategy of the given type with the provided funds
         access(all) fun createStrategy(
-            _ type: Type,
+            _ _type: Type,
             uniqueID: DeFiActions.UniqueIdentifier,
             withFunds: @{FungibleToken.Vault}
         ): @{FlowYieldVaults.Strategy} {
@@ -496,8 +496,6 @@ access(all) contract MockStrategies {
 
     init() {
         self.IssuerStoragePath = StoragePath(identifier: "MockStrategiesComposerIssuer_\(self.account.address)")!
-
-        let initialCollateralType = Type<@FlowToken.Vault>()
 
         let configs: {Type: {Type: {Type: {String: AnyStruct}}}} = {
                 Type<@TracerStrategyComposer>(): {

--- a/cadence/contracts/mocks/MockStrategy.cdc
+++ b/cadence/contracts/mocks/MockStrategy.cdc
@@ -13,7 +13,7 @@ import "FlowYieldVaults"
 access(all) contract MockStrategy {
 
     access(all) let IssuerStoragePath : StoragePath
-    
+
     access(all) struct Sink : DeFiActions.Sink {
         access(contract) var uniqueID: DeFiActions.UniqueIdentifier?
         init(_ id: DeFiActions.UniqueIdentifier?) {
@@ -25,7 +25,7 @@ access(all) contract MockStrategy {
         access(all) fun minimumCapacity(): UFix64 {
             return 0.0
         }
-        access(all) fun depositCapacity(from: auth(FungibleToken.Withdraw) &{FungibleToken.Vault}) {
+        access(all) fun depositCapacity(from _: auth(FungibleToken.Withdraw) &{FungibleToken.Vault}) {
             return
         }
         access(all) fun getComponentInfo(): DeFiActions.ComponentInfo {
@@ -53,7 +53,7 @@ access(all) contract MockStrategy {
         access(all) fun minimumAvailable(): UFix64 {
             return 0.0
         }
-        access(FungibleToken.Withdraw) fun withdrawAvailable(maxAmount: UFix64): @{FungibleToken.Vault} {
+        access(FungibleToken.Withdraw) fun withdrawAvailable(maxAmount _: UFix64): @{FungibleToken.Vault} {
             return <- DeFiActionsUtils.getEmptyVault(self.getSourceType())
         }
         access(all) fun getComponentInfo(): DeFiActions.ComponentInfo {
@@ -143,15 +143,15 @@ access(all) contract MockStrategy {
         access(all) view fun getComposedStrategyTypes(): {Type: Bool} {
             return { Type<@Strategy>(): true }
         }
-        access(all) view fun getSupportedInitializationVaults(forStrategy: Type): {Type: Bool} {
+        access(all) view fun getSupportedInitializationVaults(forStrategy _: Type): {Type: Bool} {
             return { Type<@FlowToken.Vault>(): true }
         }
-        access(all) view fun getSupportedInstanceVaults(forStrategy: Type, initializedWith: Type): {Type: Bool} {
+        access(all) view fun getSupportedInstanceVaults(forStrategy _strategy: Type, initializedWith _type: Type): {Type: Bool} {
             return { Type<@FlowToken.Vault>(): true }
         }
         access(all) fun createStrategy(
-            _ type: Type,
-            uniqueID: DeFiActions.UniqueIdentifier,
+            _ _type: Type,
+            uniqueID _: DeFiActions.UniqueIdentifier,
             withFunds: @{FungibleToken.Vault}
         ): @{FlowYieldVaults.Strategy} {
             let id = DeFiActions.createUniqueIdentifier()

--- a/cadence/contracts/mocks/YieldToken.cdc
+++ b/cadence/contracts/mocks/YieldToken.cdc
@@ -29,11 +29,11 @@ access(all) contract YieldToken : FungibleToken {
     /// and store the returned Vault in their storage in order to allow their
     /// account to be able to receive deposits of this token type.
     ///
-    access(all) fun createEmptyVault(vaultType: Type): @YieldToken.Vault {
+    access(all) fun createEmptyVault(vaultType _: Type): @YieldToken.Vault {
         return <- create Vault(balance: 0.0)
     }
 
-    access(all) view fun getContractViews(resourceType: Type?): [Type] {
+    access(all) view fun getContractViews(resourceType _: Type?): [Type] {
         return [
             Type<FungibleTokenMetadataViews.FTView>(),
             Type<FungibleTokenMetadataViews.FTDisplay>(),
@@ -42,7 +42,7 @@ access(all) contract YieldToken : FungibleToken {
         ]
     }
 
-    access(all) fun resolveContractView(resourceType: Type?, viewType: Type): AnyStruct? {
+    access(all) fun resolveContractView(resourceType _: Type?, viewType: Type): AnyStruct? {
         switch viewType {
             case Type<FungibleTokenMetadataViews.FTView>():
                 return FungibleTokenMetadataViews.FTView(

--- a/cadence/contracts/mocks/incrementfi/SwapPairTemplate.cdc
+++ b/cadence/contracts/mocks/incrementfi/SwapPairTemplate.cdc
@@ -28,7 +28,7 @@ access(all) contract SwapPair: FungibleToken {
     access(all) var price0CumulativeLastScaled: UInt256
     access(all) var price1CumulativeLastScaled: UInt256
 
-    /// Transaction lock 
+    /// Transaction lock
     access(self) var lock: Bool
 
     /// √(reserve0 * reserve1) for volatile pool, or √√[(r0^3 * r1 + r0 * r1^3) / 2] for stable pool, as of immediately after the most recent liquidity event
@@ -92,7 +92,7 @@ access(all) contract SwapPair: FungibleToken {
         /// SwapPair doesn't support MetadataViews api as this is not just a normal FT, and there could be multiple types of lpTokens
         /// for different SwapPairs, so it is stored in LpTokenCollection instead (not directly associated with a StoragePath).
         access(all) view fun getViews(): [Type] { return [] }
-        access(all) fun resolveView(_ view: Type): AnyStruct? { return nil }
+        access(all) fun resolveView(_ _view: Type): AnyStruct? { return nil }
 
         /// withdraw
         ///
@@ -166,8 +166,8 @@ access(all) contract SwapPair: FungibleToken {
     ///
     /// SwapPair doesn't support MetadataViews api as this is not just a normal FT, and there could be multiple types of lpTokens
     /// for different SwapPairs, so it is stored in LpTokenCollection instead (not directly associated with a StoragePath).
-    access(all) view fun getContractViews(resourceType: Type?): [Type] { return [] }
-    access(all) fun resolveContractView(resourceType: Type?, viewType: Type): AnyStruct? { return nil }
+    access(all) view fun getContractViews(resourceType _: Type?): [Type] { return [] }
+    access(all) fun resolveContractView(resourceType _resourceType: Type?, viewType _viewType: Type): AnyStruct? { return nil }
 
     /// createEmptyVault
     //
@@ -176,7 +176,7 @@ access(all) contract SwapPair: FungibleToken {
     /// and store the returned Vault in their storage in order to allow their
     /// account to be able to receive deposits of this token type.
     ///
-    access(all) fun createEmptyVault(vaultType: Type): @SwapPair.Vault {
+    access(all) fun createEmptyVault(vaultType _: Type): @SwapPair.Vault {
         return <-create Vault(balance: 0.0)
     }
 
@@ -191,7 +191,7 @@ access(all) contract SwapPair: FungibleToken {
         self.totalSupply = self.totalSupply + amount
         emit TokensMinted(amount: amount)
         return <- create Vault(balance: amount)
-    } 
+    }
 
     /// Burn lpTokens
     access(self) fun burnLpToken(from: @SwapPair.Vault) {
@@ -210,7 +210,7 @@ access(all) contract SwapPair: FungibleToken {
                 msg: "SwapPair: added zero liquidity",
                 err: SwapError.ErrorCode.ADD_ZERO_LIQUIDITY
             )
-            (tokenAVault.isInstance(self.token0VaultType) && tokenBVault.isInstance(self.token1VaultType)) || 
+            (tokenAVault.isInstance(self.token0VaultType) && tokenBVault.isInstance(self.token1VaultType)) ||
             (tokenBVault.isInstance(self.token0VaultType) && tokenAVault.isInstance(self.token1VaultType)):
             SwapError.ErrorEncode(
                 msg: "SwapPair: added incompatible liquidity pair vaults",
@@ -533,7 +533,7 @@ self.lock = false
             self.price1CumulativeLastScaled = SwapConfig.overflowAddUInt256(
                 self.price1CumulativeLastScaled,
                 SwapConfig.UFix64ToScaledUInt256(price1) * timeElapsedScaled / SwapConfig.scaleFactor
-            )   
+            )
         }
         self.blockTimestampLast = blockTimestamp
     }

--- a/cadence/scripts/diag_univ3_dust.cdc
+++ b/cadence/scripts/diag_univ3_dust.cdc
@@ -63,15 +63,11 @@ access(all) fun main(
     // 4) Read token decimals
     let decA = FlowEVMBridgeUtils.getTokenDecimals(evmContractAddress: tokenA)
     let decB = FlowEVMBridgeUtils.getTokenDecimals(evmContractAddress: tokenB)
-    let aIsToken0 = token0.toString() == tokenA.toString()
-    let dec0: UInt8 = aIsToken0 ? decA : decB
-    let dec1: UInt8 = aIsToken0 ? decB : decA
 
     // 5) Compute price ratio from sqrtPriceX96
     //    price = (sqrtPriceX96 / 2^96)^2
     //    price of token0 in token1 units: token1_amount / token0_amount
     //    We need to account for decimal differences
-    let Q96: UInt256 = UInt256(1) << 96
 
     // --- Worst-case dust computation ---
     // The worst-case input overshoot is quantum - 1 wei

--- a/cadence/tests/forked_rebalance_boundary_test.cdc
+++ b/cadence/tests/forked_rebalance_boundary_test.cdc
@@ -307,7 +307,7 @@ fun test_UpperBoundary() {
             signer: coaOwnerAccount
         )
 
-        let balanceBefore = getYieldVaultBalance(address: user.address, yieldVaultID: yieldVaultIDs![0])!
+        let _balanceBefore = getYieldVaultBalance(address: user.address, yieldVaultID: yieldVaultIDs![0])!
 
         // Now set to test price
         setVaultSharePrice(
@@ -505,7 +505,7 @@ fun test_LowerBoundary() {
             signer: coaOwnerAccount
         )
 
-        let balanceBefore = getYieldVaultBalance(address: user.address, yieldVaultID: yieldVaultIDs![0])!
+        let _balanceBefore = getYieldVaultBalance(address: user.address, yieldVaultID: yieldVaultIDs![0])!
 
         // Set to test price
         setVaultSharePrice(

--- a/cadence/tests/forked_rebalance_scenario2_test.cdc
+++ b/cadence/tests/forked_rebalance_scenario2_test.cdc
@@ -341,7 +341,7 @@ fun test_RebalanceYieldVaultScenario2() {
 	]
 
 	// Likely 0.0
-	let flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
+	let _flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
 	transferFlow(signer: whaleFlowAccount, recipient: user.address, amount: fundingAmount)
     grantBeta(flowYieldVaultsAccount, user)
 

--- a/cadence/tests/forked_rebalance_scenario3c_test.cdc
+++ b/cadence/tests/forked_rebalance_scenario3c_test.cdc
@@ -147,7 +147,7 @@ fun test_ForkedRebalanceYieldVaultScenario3C() {
     let user = Test.createAccount()
 
     // Likely 0.0
-    let flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
+    let _flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
     transferFlow(signer: whaleFlowAccount, recipient: user.address, amount: fundingAmount)
     grantBeta(flowYieldVaultsAccount, user)
 

--- a/cadence/tests/forked_rebalance_scenario3d_test.cdc
+++ b/cadence/tests/forked_rebalance_scenario3d_test.cdc
@@ -148,7 +148,7 @@ fun test_ForkedRebalanceYieldVaultScenario3D() {
     let user = Test.createAccount()
 
     // Likely 0.0
-    let flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
+    let _flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
     transferFlow(signer: whaleFlowAccount, recipient: user.address, amount: fundingAmount)
     grantBeta(flowYieldVaultsAccount, user)
 

--- a/cadence/tests/forked_rebalance_scenario4_test.cdc
+++ b/cadence/tests/forked_rebalance_scenario4_test.cdc
@@ -536,7 +536,7 @@ fun test_RebalanceHighCollateralLowYieldPrices() {
 	log("  FLOW collateral: \(collateralBeforeClose) FLOW")
 	log("  MOET debt:       \(debtBeforeClose) MOET")
 
-	let flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
+	let _flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
 
 	// Close the yield vault
 	// log("\n[Scenario5] Closing yield vault...")

--- a/cadence/tests/rebalance_scenario1_test.cdc
+++ b/cadence/tests/rebalance_scenario1_test.cdc
@@ -102,7 +102,7 @@ fun test_RebalanceYieldVaultScenario1() {
 	}
 
 	// Likely 0.0
-	let flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
+	let _flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
 	mintFlow(to: user, amount: fundingAmount)
     grantBeta(flowYieldVaultsAccount, user)
 

--- a/cadence/tests/rebalance_yield_test.cdc
+++ b/cadence/tests/rebalance_yield_test.cdc
@@ -91,7 +91,7 @@ fun test_RebalanceYieldVaultScenario2() {
     ]
 
     // Likely 0.0
-    let flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
+    let _flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
     mintFlow(to: user, amount: fundingAmount)
     grantBeta(flowYieldVaultsAccount, user)
 

--- a/cadence/tests/test_helpers.cdc
+++ b/cadence/tests/test_helpers.cdc
@@ -162,7 +162,7 @@ fun tempUpsertBridgeTemplateChunks(_ serviceAccount: Test.TestAccount) {
     )
     Test.expect(bridgedNFTChunkResult, Test.beSucceeded())
     // Commit bridged Token code
-    let bridgedTokenChunkResult = _executeTransaction(
+    let _bridgedTokenChunkResult = _executeTransaction(
         "../../lib/flow-evm-bridge/cadence/transactions/bridge/admin/templates/upsert_contract_code_chunks.cdc",
         ["bridgedToken", bridgedTokenCodeChunks],
         serviceAccount
@@ -489,7 +489,7 @@ access(self) fun _deploy(config: DeploymentConfig) {
 
 access(all)
 fun setupFlowALP(signer: Test.TestAccount) {
-    let res = _executeTransaction("../../lib/FlowALP/cadence/transactions/flow-alp/create_and_store_pool.cdc",
+    let _res = _executeTransaction("../../lib/FlowALP/cadence/transactions/flow-alp/create_and_store_pool.cdc",
         [],
         signer
     )
@@ -1123,7 +1123,7 @@ access(all) let uniV2RouterBytecode = "60c06040523480156200001157600080fd5b50604
 access(all)
 fun setupUniswapV2(_ signer: Test.TestAccount, feeToSetter: String, wflowAddress: String): String {
     // deserialize the feeToSetter & WFLOW addresses
-    let feeToSetterAddr = EVM.addressFromString(feeToSetter)
+    let _feeToSetterAddr = EVM.addressFromString(feeToSetter)
     let wflowAddr = EVM.addressFromString(wflowAddress)
     // deploy uniV2Factory, concatenating feeToSetter as constructor arg
     let factoryArgsBytecode = EVM.encodeABI([feeToSetter])

--- a/cadence/tests/tracer_strategy_test.cdc
+++ b/cadence/tests/tracer_strategy_test.cdc
@@ -236,7 +236,7 @@ fun test_RebalanceYieldVaultSucceeds() {
     let yieldVaultID = yieldVaultIDs![0]
 
     let autoBalancerValueBefore = getAutoBalancerCurrentValue(id: yieldVaultID)!
-    let yieldVaultBalanceBeforePriceIncrease = getYieldVaultBalance(address: user.address, yieldVaultID: yieldVaultID)
+    let _yieldVaultBalanceBeforePriceIncrease = getYieldVaultBalance(address: user.address, yieldVaultID: yieldVaultID)
 
     setMockOraclePrice(signer: flowYieldVaultsAccount,
         forTokenIdentifier: yieldTokenIdentifier,
@@ -244,7 +244,7 @@ fun test_RebalanceYieldVaultSucceeds() {
     )
 
     let autoBalancerValueAfter = getAutoBalancerCurrentValue(id: yieldVaultID)!
-    let yieldVaultBalanceAfterPriceIncrease = getYieldVaultBalance(address: user.address, yieldVaultID: yieldVaultID)
+    let _yieldVaultBalanceAfterPriceIncrease = getYieldVaultBalance(address: user.address, yieldVaultID: yieldVaultID)
 
     // Rebalance YieldVault: AutoBalancer detects surplus (YT value increased from $61.54 to $73.85)
     // and pushes excess value to Position via rebalanceSink (positionSwapSink: YT -> FLOW swap -> Position)
@@ -373,7 +373,7 @@ fun test_RebalanceYieldVaultSucceedsAfterCollateralPriceIncrease() {
     let user = Test.createAccount()
 
     // Likely 0.0
-    let flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
+    let _flowBalanceBefore = getBalance(address: user.address, vaultPublicPath: /public/flowTokenReceiver)!
     mintFlow(to: user, amount: fundingAmount)
     grantBeta(flowYieldVaultsAccount, user)
 

--- a/cadence/tests/transactions/execute_univ3_swap.cdc
+++ b/cadence/tests/transactions/execute_univ3_swap.cdc
@@ -30,7 +30,8 @@ transaction(
         self.coaCap = signer.capabilities.storage.issue<auth(EVM.Owner, EVM.Bridge) &EVM.CadenceOwnedAccount>(/storage/evm)
 
         let inAddr = EVM.addressFromString(inTokenAddress)
-        let inType = FlowEVMBridgeConfig.getTypeAssociated(with: inAddr)!
+        // TODO: remove?
+        let _inType = FlowEVMBridgeConfig.getTypeAssociated(with: inAddr)!
         let feeVault = signer.capabilities.storage.issue<auth(FungibleToken.Withdraw) &{FungibleToken.Vault}>(/storage/flowTokenVault)
         self.tokenSource = FungibleTokenConnectors.VaultSinkAndSource(
             min: nil,

--- a/cadence/transactions/flow-yield-vaults/admin/destroy_and_reset_supervisor.cdc
+++ b/cadence/transactions/flow-yield-vaults/admin/destroy_and_reset_supervisor.cdc
@@ -24,7 +24,7 @@ transaction(
 
     prepare(signer: auth(BorrowValue, LoadValue, StorageCapabilities) &Account) {
         // remove the stored Capability used for internal recurring execution
-        let supervisorCap = signer.storage
+        let _supervisorCap = signer.storage
             .load<Capability<auth(FlowTransactionScheduler.Execute) &{FlowTransactionScheduler.TransactionHandler}>>(
                 from: /storage/FlowYieldVaultsSupervisorCapability
             )

--- a/cadence/transactions/flow-yield-vaults/admin/destroy_supervisor.cdc
+++ b/cadence/transactions/flow-yield-vaults/admin/destroy_supervisor.cdc
@@ -11,7 +11,7 @@ transaction {
     let supervisor: @FlowYieldVaultsSchedulerV1.Supervisor?
 
     prepare(signer: auth(LoadValue, StorageCapabilities) &Account) {
-        let supervisorCap = signer.storage
+        let _supervisorCap = signer.storage
             .load<Capability<auth(FlowTransactionScheduler.Execute) &{FlowTransactionScheduler.TransactionHandler}>>(
                 from: /storage/FlowYieldVaultsSupervisorCapability
             )

--- a/cadence/transactions/test/self_grant_beta.cdc
+++ b/cadence/transactions/test/self_grant_beta.cdc
@@ -8,21 +8,19 @@ transaction() {
         let handle = signer.storage.borrow<auth(FlowYieldVaultsClosedBeta.Admin) &FlowYieldVaultsClosedBeta.AdminHandle>(
             from: FlowYieldVaultsClosedBeta.AdminHandleStoragePath
         ) ?? panic("Missing AdminHandle at \(FlowYieldVaultsClosedBeta.AdminHandleStoragePath)")
-        
+
         // Grant beta to self
         let cap = handle.grantBeta(addr: signer.address)
-        
+
         // Save the beta capability
         let storagePath = FlowYieldVaultsClosedBeta.UserBetaCapStoragePath
-        
+
         // Remove any existing capability
-        if let existing = signer.storage.load<Capability<auth(FlowYieldVaultsClosedBeta.Beta) &FlowYieldVaultsClosedBeta.BetaBadge>>(from: storagePath) {
-            // Old cap exists, remove it
-        }
-        
+        let _existing = signer.storage.load<Capability<auth(FlowYieldVaultsClosedBeta.Beta) &FlowYieldVaultsClosedBeta.BetaBadge>>(from: storagePath)
+
         // Save the new capability
         signer.storage.save(cap, to: storagePath)
-        
+
         log("✅ Beta granted to self!")
         log("   StoragePath: ".concat(storagePath.toString()))
     }


### PR DESCRIPTION
## Description

Prepare for #223 

Used the linter to find unused variables and parameters.

There are several unused variables in the tests, results of calls to `getBalance` and `getYieldVaultBalance` – can these actually be deleted if the result is unused, or are they asserting the balance can be get?

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/FlowYieldVaults-sc/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 