### PR TITLE
Clean up redundant type annotations and force unwraps, use if-let where possible

### DIFF
--- a/cadence/contracts/FlowYieldVaultsAutoBalancers.cdc
+++ b/cadence/contracts/FlowYieldVaultsAutoBalancers.cdc
@@ -114,7 +114,7 @@ access(all) contract FlowYieldVaultsAutoBalancers {
         }
 
         let currentTimestamp = getCurrentBlock().timestamp
-        let optimisticExecutionGracePeriod: UFix64 = 15.0
+        let optimisticExecutionGracePeriod = 15.0
         let txnIDs = autoBalancer!.getScheduledTransactionIDs()
         for txnID in txnIDs {
             if let scheduledTxn = autoBalancer!.borrowScheduledTransaction(id: txnID) {
@@ -270,9 +270,8 @@ access(all) contract FlowYieldVaultsAutoBalancers {
         // This schedules the first rebalance; subsequent ones are scheduled automatically
         // by the AutoBalancer after each execution (via recurringConfig)
         if recurringConfig != nil {
-            let scheduleError = autoBalancerRef.scheduleNextRebalance(whileExecuting: nil)
-            if scheduleError != nil {
-                panic("Failed to schedule first rebalance for AutoBalancer \(uniqueID.id): ".concat(scheduleError!))
+            if let scheduleError = autoBalancerRef.scheduleNextRebalance(whileExecuting: nil) {
+                panic("Failed to schedule first rebalance for AutoBalancer \(uniqueID.id): \(scheduleError)")
             }
         }
 

--- a/cadence/contracts/FlowYieldVaultsStrategiesV2.cdc
+++ b/cadence/contracts/FlowYieldVaultsStrategiesV2.cdc
@@ -159,7 +159,7 @@ access(all) contract FlowYieldVaultsStrategiesV2 {
             )
 
             // Step 2: Calculate total debt amount
-            var totalDebtAmount: UFix64 = 0.0
+            var totalDebtAmount = 0.0
             for debtAmount in debtsByType.values {
                 totalDebtAmount = totalDebtAmount + debtAmount
             }
@@ -193,7 +193,7 @@ access(all) contract FlowYieldVaultsStrategiesV2 {
                 ?? panic("Could not create external source from AutoBalancer")
 
             // Step 5: Retrieve yield→MOET swapper from contract config
-            let swapperKey = FlowYieldVaultsStrategiesV2.getYieldToMoetSwapperConfigKey(self.uniqueID)!
+            let swapperKey = FlowYieldVaultsStrategiesV2.getYieldToMoetSwapperConfigKey(self.uniqueID)
             let yieldToMoetSwapper = FlowYieldVaultsStrategiesV2.config[swapperKey] as! {DeFiActions.Swapper}?
                 ?? panic("No yield→MOET swapper found for strategy \(self.id()!)")
 
@@ -464,7 +464,7 @@ access(all) contract FlowYieldVaultsStrategiesV2 {
             balancerIO.autoBalancer.setSource(positionSwapSource, updateSourceID: true)
 
             // Store yield→MOET swapper in contract config for later access during closePosition
-            let yieldToMoetSwapperKey = FlowYieldVaultsStrategiesV2.getYieldToMoetSwapperConfigKey(uniqueID)!
+            let yieldToMoetSwapperKey = FlowYieldVaultsStrategiesV2.getYieldToMoetSwapperConfigKey(uniqueID)
             FlowYieldVaultsStrategiesV2.config[yieldToMoetSwapperKey] = yieldToMoetSwapper
 
             // @TODO implement moet to collateral swapper
@@ -907,7 +907,7 @@ access(all) contract FlowYieldVaultsStrategiesV2 {
             for stratType in config {
                 let newPerCollateral = config[stratType]!
                 let existingPerCollateral = mergedComposerConfig[stratType] ?? {}
-                var mergedPerCollateral: {Type: FlowYieldVaultsStrategiesV2.CollateralConfig} = existingPerCollateral
+                var mergedPerCollateral = existingPerCollateral
 
                 for collateralType in newPerCollateral {
                     mergedPerCollateral[collateralType] = newPerCollateral[collateralType]!

--- a/cadence/contracts/PMStrategiesV1.cdc
+++ b/cadence/contracts/PMStrategiesV1.cdc
@@ -603,12 +603,12 @@ access(all) contract PMStrategiesV1 {
             }
             // Merge instead of overwrite
             let existingComposerConfig = self.configs[composer] ?? {}
-            var mergedComposerConfig: {Type: {Type: {String: AnyStruct}}} = existingComposerConfig
+            var mergedComposerConfig = existingComposerConfig
 
             for stratType in config {
                 let newPerCollateral = config[stratType]!
                 let existingPerCollateral = mergedComposerConfig[stratType] ?? {}
-                var mergedPerCollateral: {Type: {String: AnyStruct}} = existingPerCollateral
+                var mergedPerCollateral = existingPerCollateral
 
                 for collateralType in newPerCollateral {
                     mergedPerCollateral[collateralType] = newPerCollateral[collateralType]!

--- a/cadence/contracts/mocks/EVM.cdc
+++ b/cadence/contracts/mocks/EVM.cdc
@@ -736,7 +736,7 @@ contract EVM {
         let seenAccountKeyIndices: {Int: Int} = {}
         for signatureIndex, signature in signatures{
             // index of the key on the account
-            let accountKeyIndex = Int(keyIndices[signatureIndex]!)
+            let accountKeyIndex = Int(keyIndices[signatureIndex])
             // index of the key in the key list
             var keyListIndex = 0
 

--- a/cadence/contracts/mocks/FlowTransactionScheduler.cdc
+++ b/cadence/contracts/mocks/FlowTransactionScheduler.cdc
@@ -548,8 +548,8 @@ access(all) contract FlowTransactionScheduler {
 
         access(all) init() {
             self.nextID = 1
-            self.canceledTransactions = [0 as UInt64]
-            
+            self.canceledTransactions = [0]
+
             self.transactions = {}
             self.slotUsedEffort = {}
             self.slotQueue = {}
@@ -707,7 +707,7 @@ access(all) contract FlowTransactionScheduler {
         /// @return Status: The status of the transaction, if the transaction is not found Unknown is returned.
         access(contract) view fun getStatus(id: UInt64): Status? {
             // if the transaction ID is greater than the next ID, it is not scheduled yet and has never existed
-            if id == 0 as UInt64 || id >= self.nextID {
+            if id == 0  || id >= self.nextID {
                 return nil
             }
 
@@ -772,8 +772,8 @@ access(all) contract FlowTransactionScheduler {
                 executionEffort: executionEffort
             )
 
-            if estimate.error != nil {
-                panic(estimate.error!)
+            if let estimationError = estimate.error {
+                panic(estimationError)
             }
 
             assert (
@@ -1299,7 +1299,7 @@ access(all) contract FlowTransactionScheduler {
             self.slotQueue = {}
             self.slotUsedEffort = {}
             self.sortedTimestamps = SortedTimestamps()
-            self.canceledTransactions = [0 as UInt64]
+            self.canceledTransactions = [0]
         }
     }
 

--- a/cadence/contracts/mocks/MockStrategies.cdc
+++ b/cadence/contracts/mocks/MockStrategies.cdc
@@ -109,7 +109,7 @@ access(all) contract MockStrategies {
             let debtsByType = self.position.getTotalDebt()
 
             // Step 2: Calculate total debt amount across all debt types
-            var totalDebtAmount: UFix64 = 0.0
+            var totalDebtAmount = 0.0
             for debtAmount in debtsByType.values {
                 totalDebtAmount = totalDebtAmount + debtAmount
             }
@@ -282,7 +282,7 @@ access(all) contract MockStrategies {
 
             // assign token types
 
-            let moetTokenType: Type = Type<@MOET.Vault>()
+            let moetTokenType = Type<@MOET.Vault>()
             let yieldTokenType = Type<@YieldToken.Vault>()
             // assign collateral & flow token types
             let collateralType = withFunds.getType()

--- a/cadence/contracts/mocks/incrementfi/SwapPairTemplate.cdc
+++ b/cadence/contracts/mocks/incrementfi/SwapPairTemplate.cdc
@@ -407,14 +407,14 @@ access(all) fun swap(vaultIn: @{FungibleToken.Vault}, exactAmountOut: UFix64?): 
         }
     }
     /// Check and swap exact output amount if specified in argument
-    if exactAmountOut != nil {
-        assert(amountOut >= exactAmountOut!, message:
+    if let exactAmountOut = exactAmountOut {
+        assert(amountOut >= exactAmountOut, message:
         SwapError.ErrorEncode(
             msg: "SwapPair: INSUFFICIENT_OUTPUT_AMOUNT",
             err: SwapError.ErrorCode.INSUFFICIENT_OUTPUT_AMOUNT
         )
     )
-    amountOut = exactAmountOut!
+    amountOut = exactAmountOut
 }
 
 if (vaultIn.isInstance(self.token0VaultType)) {
@@ -573,12 +573,12 @@ self.lock = false
 }
 
 access(all) view fun _rootK(balance0: UFix64, balance1: UFix64): UFix64 {
-    let e18: UInt256 = SwapConfig.scaleFactor
+    let e18 = SwapConfig.scaleFactor
     let balance0Scaled = SwapConfig.UFix64ToScaledUInt256(balance0)
     let balance1Scaled = SwapConfig.UFix64ToScaledUInt256(balance1)
     if self.isStableSwap() {
-        let _p_scaled: UInt256 = SwapConfig.UFix64ToScaledUInt256(self.getStableCurveP())
-        let _k_scaled: UInt256 = SwapConfig.k_stable_p(balance0Scaled, balance1Scaled, _p_scaled)
+        let _p_scaled = SwapConfig.UFix64ToScaledUInt256(self.getStableCurveP())
+        let _k_scaled = SwapConfig.k_stable_p(balance0Scaled, balance1Scaled, _p_scaled)
         return SwapConfig.ScaledUInt256ToUFix64(SwapConfig.sqrt(SwapConfig.sqrt(_k_scaled / 2)))
     } else {
         return SwapConfig.ScaledUInt256ToUFix64(SwapConfig.sqrt(balance0Scaled * balance1Scaled / e18))


### PR DESCRIPTION

## Description

Continue preparation for #223 

Used the linter to find cases where if-let can be used, and redundant type annotations and force unwraps

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/FlowYieldVaults-sc/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 